### PR TITLE
Allow custom CSS selector for scraping

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -5,6 +5,8 @@ import logging
 
 import scrape_images
 
+DEFAULT_SELECTOR = scrape_images.DEFAULT_SELECTOR
+
 class TextHandler(logging.Handler):
     """Redirect logging records to a Tkinter Text widget."""
     def __init__(self, text_widget: tk.Text):
@@ -19,7 +21,7 @@ class TextHandler(logging.Handler):
         self.text_widget.yview(tk.END)
 
 
-def start_scraping(url: str, text_widget: tk.Text, button: tk.Button) -> None:
+def start_scraping(url: str, selector: str, text_widget: tk.Text, button: tk.Button) -> None:
     handler = TextHandler(text_widget)
     logger = logging.getLogger("scraper")
     logger.setLevel(logging.INFO)
@@ -27,7 +29,7 @@ def start_scraping(url: str, text_widget: tk.Text, button: tk.Button) -> None:
     logger.addHandler(handler)
 
     def run() -> None:
-        scrape_images.scrape_images(url, logger)
+        scrape_images.scrape_images(url, logger, selector)
         button.config(state=tk.NORMAL)
 
     threading.Thread(target=run, daemon=True).start()
@@ -42,6 +44,14 @@ def main() -> None:
     url_entry.insert(0, scrape_images.PRODUCT_URL)
     url_entry.pack(padx=5, pady=5)
 
+    tk.Label(
+        root,
+        text="S\u00e9lecteur CSS personnalis\u00e9 (laisser vide pour la valeur par d\u00e9faut) :",
+    ).pack(padx=5, pady=(0, 0))
+    selector_entry = tk.Entry(root, width=80)
+    selector_entry.insert(0, DEFAULT_SELECTOR)
+    selector_entry.pack(padx=5, pady=5)
+
     start_button = tk.Button(root, text="Scraper les images")
     start_button.pack(pady=(0, 5))
 
@@ -52,11 +62,12 @@ def main() -> None:
         url = url_entry.get().strip()
         if not url:
             return
+        selector = selector_entry.get().strip() or DEFAULT_SELECTOR
         start_button.config(state=tk.DISABLED)
         log_text.configure(state="normal")
         log_text.delete("1.0", tk.END)
         log_text.configure(state="disabled")
-        start_scraping(url, log_text, start_button)
+        start_scraping(url, selector, log_text, start_button)
 
     start_button.config(command=on_click)
 


### PR DESCRIPTION
## Summary
- allow passing a CSS selector from the interface to the scraper
- add GUI entry for custom selector
- update scraping engine to use given selector

## Testing
- `python -m py_compile interface.py scrape_images.py`
- `pip install -r requirements.txt`
- `python scrape_images.py` *(fails: Could not reach host)*
- `python interface.py` *(fails: no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68630cbc7d408330a4689cf008d9e173