### PR TITLE
Add argparse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,27 @@ pip install -r requirements.txt
 Note : Pas besoin d’installer manuellement ChromeDriver. Le script utilise webdriver-manager qui détecte ta version de Chrome et installe le bon driver automatiquement.
 
 🚀 Utilisation
-Exécuter simplement le script :
-
-bash
-Copier
-Modifier
-python scrape_images.py
-Le script ouvrira une session de navigateur invisible, naviguera sur la page produit, collectera toutes les balises <img> de la galerie, et téléchargera les images localement dans le dossier images/.
-
-Pour cibler une autre page produit, renseigne simplement la variable d'environnement `PRODUCT_URL` :
+Lance le script en fournissant l'URL de la page produit :
 
 ```bash
-PRODUCT_URL="https://exemple.com/ma-page-produit" python scrape_images.py
+python scrape_images.py https://exemple.com/ma-page-produit
 ```
+
+Tu peux indiquer un sélecteur CSS personnalisé :
+
+```bash
+python scrape_images.py https://exemple.com/ma-page-produit \
+  --selector "div.gallery img"
+```
+
+Et choisir un dossier de sortie différent :
+
+```bash
+python scrape_images.py https://exemple.com/ma-page-produit \
+  --selector "div.gallery img" --output-dir mes_images
+```
+
+Par défaut, le sélecteur utilisé est `div[data-media-type='image'] img` et les images sont enregistrées dans `./images`.
 
 🖥️ Interface graphique
 Une fenêtre Tkinter permet de lancer le scraping sans passer par la ligne de

--- a/scrape_images.py
+++ b/scrape_images.py
@@ -3,6 +3,7 @@ import random
 import time
 from pathlib import Path
 import logging
+import argparse
 
 import requests
 from selenium import webdriver
@@ -147,11 +148,31 @@ def scrape_images(
 
 
 def main():
+    global IMAGE_DIR
+
+    parser = argparse.ArgumentParser(description="Scrape images from a product page")
+    parser.add_argument("url", help="URL de la page produit")
+    parser.add_argument(
+        "-s",
+        "--selector",
+        default=DEFAULT_SELECTOR,
+        help="Sélecteur CSS pour cibler les images (défaut: %(default)s)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        default=str(IMAGE_DIR),
+        help="Dossier de destination des images",
+    )
+    args = parser.parse_args()
+
+    IMAGE_DIR = Path(args.output_dir)
+
     driver = setup_driver()
     try:
-        images = fetch_images(driver, PRODUCT_URL, DEFAULT_SELECTOR)
+        images = fetch_images(driver, args.url, args.selector)
         if not images:
-            print(f"Aucun élément trouvé avec le sélecteur : {DEFAULT_SELECTOR}")
+            print(f"Aucun élément trouvé avec le sélecteur : {args.selector}")
             return
         print(f"\U0001F4F8 {len(images)} images trouvées.")
         save_images(images)


### PR DESCRIPTION
## Summary
- add argparse options to specify URL, CSS selector and output directory
- default to `DEFAULT_SELECTOR` when selector not provided
- document command usage in README

## Testing
- `python -m py_compile scrape_images.py interface.py html_selector_tool.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6863dbc19c788330873d1bed3f28aa1d