### PR TITLE
Ajout renommage et scraping dans MainWindow

### DIFF
--- a/Modern_GUI_PyDracula_PySide6_or_PyQt6/main.py
+++ b/Modern_GUI_PyDracula_PySide6_or_PyQt6/main.py
@@ -40,6 +40,22 @@ class MainWindow(QMainWindow):
         self.ui.setupUi(self)
         global widgets
         widgets = self.ui
+        # —— Renommage des boutons ——
+        # Tous les boutons sauf "home" passent en "À venir"
+        widgets.btn_widgets.setText("À venir")
+        widgets.btn_new    .setText("À venir")
+        widgets.btn_save   .setText("À venir")
+        widgets.btn_exit   .setText("À venir")
+
+        # Le bouton "home" devient "Scraping Image"
+        widgets.btn_home.setText("Scraping Image")
+
+        # —— Reconnexion du clic de btn_home à la fonction de scraping ——
+        try:
+            widgets.btn_home.clicked.disconnect()
+        except TypeError:
+            pass
+        widgets.btn_home.clicked.connect(self.run_scraper)
 
         # USE CUSTOM TITLE BAR | USE AS "False" FOR MAC OR LINUX
         # ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- connect the Home button to the scraper and rename buttons

## Testing
- `python -m py_compile scrape_images.py html_selector_tool.py Modern_GUI_PyDracula_PySide6_or_PyQt6/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686410c300408330ac6cdaee9044d45a