### PR TITLE
Add interactive scraping controls

### DIFF
--- a/Modern_GUI_PyDracula_PySide6_or_PyQt6/main.ui
+++ b/Modern_GUI_PyDracula_PySide6_or_PyQt6/main.ui
@@ -2721,22 +2721,36 @@ background-repeat: no-repeat;</string>
                         </widget>
                        </item>
                        <item>
-                        <widget class="QLineEdit" name="lineEdit_url">
-                         <property name="placeholderText">
-                          <string>URL du produit</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QPushButton" name="btn_launch_scraping">
-                         <property name="text">
-                          <string>Lancer le scraping</string>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </widget>
+                       <widget class="QLineEdit" name="lineEdit_url">
+                        <property name="placeholderText">
+                         <string>URL du produit</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLineEdit" name="lineEdit_selector">
+                        <property name="placeholderText">
+                         <string>Sélecteur CSS</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QPushButton" name="btn_launch_scraping">
+                        <property name="text">
+                         <string>Lancer le scraping</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QTextEdit" name="log_browser">
+                        <property name="readOnly">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
                     </widget>
+                   </widget>
                    </item>
                   </layout>
                  </widget>

--- a/Modern_GUI_PyDracula_PySide6_or_PyQt6/modules/ui_main.py
+++ b/Modern_GUI_PyDracula_PySide6_or_PyQt6/modules/ui_main.py
@@ -1393,10 +1393,21 @@ class Ui_MainWindow(object):
 
         self.verticalLayout_20.addWidget(self.lineEdit_url)
 
+        self.lineEdit_selector = QLineEdit(self.new_page)
+        self.lineEdit_selector.setObjectName(u"lineEdit_selector")
+
+        self.verticalLayout_20.addWidget(self.lineEdit_selector)
+
         self.btn_launch_scraping = QPushButton(self.new_page)
         self.btn_launch_scraping.setObjectName(u"btn_launch_scraping")
 
         self.verticalLayout_20.addWidget(self.btn_launch_scraping)
+
+        self.log_browser = QTextEdit(self.new_page)
+        self.log_browser.setObjectName(u"log_browser")
+        self.log_browser.setReadOnly(True)
+
+        self.verticalLayout_20.addWidget(self.log_browser)
 
         self.stackedWidget.addWidget(self.new_page)
 
@@ -1664,6 +1675,7 @@ class Ui_MainWindow(object):
 
         self.label.setText(QCoreApplication.translate("MainWindow", u"NEW PAGE TEST", None))
         self.lineEdit_url.setPlaceholderText(QCoreApplication.translate("MainWindow", u"URL du produit", None))
+        self.lineEdit_selector.setPlaceholderText(QCoreApplication.translate("MainWindow", u"Sélecteur CSS", None))
         self.btn_launch_scraping.setText(QCoreApplication.translate("MainWindow", u"Lancer le scraping", None))
         self.btn_message.setText(QCoreApplication.translate("MainWindow", u"Message", None))
         self.btn_print.setText(QCoreApplication.translate("MainWindow", u"Print", None))


### PR DESCRIPTION
## Summary
- add CSS selector field and log browser to new_page
- wire up scraping button with dynamic fields and logging

## Testing
- `python -m py_compile Modern_GUI_PyDracula_PySide6_or_PyQt6/main.py Modern_GUI_PyDracula_PySide6_or_PyQt6/modules/ui_main.py scrape_images.py html_selector_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_686419a9714883308803764dc8af98c3